### PR TITLE
Issues list loading and error handling

### DIFF
--- a/Github Issue Reader.xcodeproj/project.pbxproj
+++ b/Github Issue Reader.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B68DE151293E90BF005E4A8F /* IssueLoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68DE150293E90BF005E4A8F /* IssueLoadingCell.swift */; };
 		B6AD210528FF4E18009B3345 /* GithubIssueReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AD210428FF4E18009B3345 /* GithubIssueReaderTests.swift */; };
 		B6AD210C28FF5263009B3345 /* IssueViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AD210B28FF5263009B3345 /* IssueViewModelTests.swift */; };
 		FD157EF428C0032000A05E12 /* IssuesCollectionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD157EF328C0032000A05E12 /* IssuesCollectionVC.swift */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B68DE150293E90BF005E4A8F /* IssueLoadingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueLoadingCell.swift; sourceTree = "<group>"; };
 		B6AD210228FF4E18009B3345 /* GithubIssueReaderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GithubIssueReaderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6AD210428FF4E18009B3345 /* GithubIssueReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubIssueReaderTests.swift; sourceTree = "<group>"; };
 		B6AD210B28FF5263009B3345 /* IssueViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueViewModelTests.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 			children = (
 				FD157EF328C0032000A05E12 /* IssuesCollectionVC.swift */,
 				FD52A5A928F9F6D100819D23 /* IssuePreviewContentView.swift */,
+				B68DE150293E90BF005E4A8F /* IssueLoadingCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 				FD52A5AA28F9F6D100819D23 /* IssuePreviewContentView.swift in Sources */,
 				FFB3D64428BE8B6C005DB032 /* ViewController.swift in Sources */,
 				FFB3D65E28BFD03B005DB032 /* IssueViewModel.swift in Sources */,
+				B68DE151293E90BF005E4A8F /* IssueLoadingCell.swift in Sources */,
 				FFB3D65728BE8E5C005DB032 /* IssueModel.swift in Sources */,
 				FD157EF428C0032000A05E12 /* IssuesCollectionVC.swift in Sources */,
 				FFB3D65928BE8FB8005DB032 /* UserModel .swift in Sources */,

--- a/Github Issue Reader/API/NetworkManager.swift
+++ b/Github Issue Reader/API/NetworkManager.swift
@@ -15,7 +15,7 @@ final class NetworkingManager {
     
     func request<T: Codable>(_ urlString: String,
                              type: T.Type,
-                             completion: @escaping (Result<T, Error>) -> Void) {
+                             completion: @escaping (Result<T, NetworkingError>) -> Void) {
         
         guard let url = URL(string: urlString) else {
             completion(.failure(NetworkingError.invalidURL))
@@ -65,5 +65,35 @@ extension NetworkingManager {
         case invalidData
         case decodingFailure(error: Error)
         case unknown(error: Error)
+
+        var title: String {
+            switch self {
+            case .invalidURL:
+                return "Invalid URL"
+            case .invalidStatusCode:
+                return "Invalid Status Code"
+            case .invalidData:
+                return "Invalid Data"
+            case .decodingFailure:
+                return "Decoding Failure"
+            case .unknown:
+                return "Unknown"
+            }
+        }
+
+        var description: String? {
+            switch self {
+            case .invalidURL:
+                return nil
+            case .invalidStatusCode(statusCode: let statusCode):
+                return "\(statusCode)"
+            case .invalidData:
+                return nil
+            case .decodingFailure(let error):
+                return error.localizedDescription
+            case .unknown(let error):
+                return error.localizedDescription
+            }
+        }
     }
 }

--- a/Github Issue Reader/ViewController.swift
+++ b/Github Issue Reader/ViewController.swift
@@ -126,9 +126,7 @@ class ViewController: UIViewController {
         navigationController?.pushViewController(issuesVC, animated: true)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            viewModel.fetchIssues(for: organization, repo: repo) { [self] issues in
-                print("Loaded \(issues?.count ?? 0) issues")
-                issuesVC.reload()
+            viewModel.fetchIssues(for: organization, repo: repo) { issues in
             }
         }
     }

--- a/Github Issue Reader/ViewController.swift
+++ b/Github Issue Reader/ViewController.swift
@@ -122,11 +122,14 @@ class ViewController: UIViewController {
         }
 
         let viewModel = IssueViewModel()
-        viewModel.fetchIssues(for: organization, repo: repo) { [self] issues in
-            print("Successfully received issues.")
+        let issuesVC = IssuesCollectionVC(viewModel: viewModel)
+        navigationController?.pushViewController(issuesVC, animated: true)
 
-            let issuesVC = IssuesCollectionVC(viewModel: viewModel)
-            navigationController?.pushViewController(issuesVC, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            viewModel.fetchIssues(for: organization, repo: repo) { [self] issues in
+                print("Loaded \(issues?.count ?? 0) issues")
+                issuesVC.reload()
+            }
         }
     }
 }

--- a/Github Issue Reader/ViewController.swift
+++ b/Github Issue Reader/ViewController.swift
@@ -85,7 +85,6 @@ class ViewController: UIViewController {
         repoTextfield.text = "Swift"
         
         setupUI()
-        activateIndicator()
     }
     
     func setupUI() {
@@ -121,32 +120,13 @@ class ViewController: UIViewController {
         guard let organization = organization, let repo = repo else {
             return
         }
-        
-        activityIndicator.startAnimating()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-            
-            let viewModel = IssueViewModel()
-            viewModel.fetchIssues(for: organization, repo: repo) { [self] issues in
-                print("Successfully received issues.")
-                
-                let issuesVC = IssuesCollectionVC(viewModel: viewModel)                
-                navigationController?.pushViewController(issuesVC, animated: true)
-                activityIndicator.stopAnimating()
-            }
+
+        let viewModel = IssueViewModel()
+        viewModel.fetchIssues(for: organization, repo: repo) { [self] issues in
+            print("Successfully received issues.")
+
+            let issuesVC = IssuesCollectionVC(viewModel: viewModel)
+            navigationController?.pushViewController(issuesVC, animated: true)
         }
     }
-    
-    let activityIndicator = UIActivityIndicatorView(style: .large)
-    
-    func activateIndicator() {
-        let container = UIView()
-        container.frame = CGRect(x: 0, y: 0, width: 0, height: 0)
-        
-        activityIndicator.center = self.view.center
-        
-        container.addSubview(activityIndicator)
-        self.view.addSubview(container)
-    }
-    
 }
-

--- a/Github Issue Reader/ViewModels/IssueViewModel.swift
+++ b/Github Issue Reader/ViewModels/IssueViewModel.swift
@@ -7,11 +7,10 @@
 
 import Foundation
 
-
 class IssueViewModel {
-    
-    var issues: [Issue] = []
-    
+
+    @Published var issues: [Issue] = []
+
     func fetchIssues(for organization: String, repo: String, completion: @escaping (_ downloadedIssues: [Issue]?) -> Void) {
          let url = "https://api.github.com/repos/\(organization)/\(repo)/issues"
          NetworkingManager.shared.request(url, type: [Issue].self) { [weak self] response in

--- a/Github Issue Reader/ViewModels/IssueViewModel.swift
+++ b/Github Issue Reader/ViewModels/IssueViewModel.swift
@@ -10,22 +10,25 @@ import Foundation
 class IssueViewModel {
 
     @Published var issues: [Issue] = []
+    @Published var error: NetworkingManager.NetworkingError?
 
     func fetchIssues(for organization: String, repo: String, completion: @escaping (_ downloadedIssues: [Issue]?) -> Void) {
-         let url = "https://api.github.com/repos/\(organization)/\(repo)/issues"
-         NetworkingManager.shared.request(url, type: [Issue].self) { [weak self] response in
-             DispatchQueue.main.async { [weak self] in
-                 guard let self = self else { return }
-                 switch response {
-                 case .success(let response):
-                     self.issues.append(contentsOf: response)
-                     completion(self.issues)
-                 case .failure(let error):
-                     print(error)
-                     completion(nil)
-                 }
-             }
-         }
+        let url = "https://api.github.com/repos/\(organization)/\(repo)/issues"
+        // Bad url for testing error logic
+//        let url = "https://api.github.com/asdjfaklsdjfaldksjflkas/repos/\(organization)/\(repo)/issues"
+        NetworkingManager.shared.request(url, type: [Issue].self) { [weak self] response in
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                switch response {
+                case .success(let response):
+                    self.issues.append(contentsOf: response)
+                    completion(self.issues)
+                case .failure(let error):
+                    self.error = error
+                    completion(nil)
+                }
+            }
+        }
      }
 
     func fetchIssuesAsync(for organization: String, repo: String) async -> [Issue]? {

--- a/Github Issue Reader/Views/IssueLoadingCell.swift
+++ b/Github Issue Reader/Views/IssueLoadingCell.swift
@@ -20,7 +20,6 @@ class IssueLoadingCell: UICollectionViewCell {
         activityIndicator.startAnimating()
 
         contentView.addSubview(activityIndicator)
-        contentView.backgroundColor = .purple
 
         NSLayoutConstraint.activate([
             contentView.leadingAnchor.constraint(equalTo: activityIndicator.leadingAnchor),

--- a/Github Issue Reader/Views/IssueLoadingCell.swift
+++ b/Github Issue Reader/Views/IssueLoadingCell.swift
@@ -1,0 +1,36 @@
+//
+//  IssueLoadingCell.swift
+//  Github Issue Reader
+//
+//  Created by Kevin Randrup on 12/5/22.
+//
+
+import UIKit
+
+class IssueLoadingCell: UICollectionViewCell {
+
+    static let identifier = "IssueLoadingCell"
+
+    private let activityIndicator = UIActivityIndicatorView(style: .large)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.startAnimating()
+
+        contentView.addSubview(activityIndicator)
+        contentView.backgroundColor = .purple
+
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(equalTo: activityIndicator.leadingAnchor),
+            contentView.topAnchor.constraint(equalTo: activityIndicator.topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: activityIndicator.bottomAnchor),
+            contentView.trailingAnchor.constraint(equalTo: activityIndicator.trailingAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Github Issue Reader/Views/IssuesCollectionVC.swift
+++ b/Github Issue Reader/Views/IssuesCollectionVC.swift
@@ -18,6 +18,7 @@ class IssuesCollectionVC: UICollectionViewController, UICollectionViewDelegateFl
     }
 
     private let viewModel: IssueViewModel
+    private let mainSection = Section(section: 0)
 
     init(viewModel: IssueViewModel) {
         let configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
@@ -37,10 +38,10 @@ class IssuesCollectionVC: UICollectionViewController, UICollectionViewDelegateFl
 
         // Load initial data
         var snapshot = dataSource.snapshot()
-        let section = Section(section: 0)
-        snapshot.appendSections([section])
-        snapshot.appendItems([.loading], toSection: section)
-        snapshot.appendItems(viewModel.issues.map({ .issue($0) }), toSection: section)
+
+        snapshot.appendSections([mainSection])
+        snapshot.appendItems([.loading], toSection: mainSection)
+
         dataSource.apply(snapshot)
     }
 
@@ -52,6 +53,14 @@ class IssuesCollectionVC: UICollectionViewController, UICollectionViewDelegateFl
         view.backgroundColor = .systemBackground
         navigationItem.title = "Issues"
         navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+    /// Issues have loaded into the `IssuesViewModel`, update the UI with the new data
+    func reload() {
+        var snapshot = dataSource.snapshot()
+        snapshot.appendItems(viewModel.issues.map { .issue($0) }, toSection: mainSection)
+        dataSource.apply(snapshot)
+        print("Displaying \(viewModel.issues.count) issues")
     }
 
     // MARK: UICollectionView

--- a/Github Issue Reader/Views/IssuesCollectionVC.swift
+++ b/Github Issue Reader/Views/IssuesCollectionVC.swift
@@ -80,6 +80,8 @@ class IssuesCollectionVC: UICollectionViewController, UICollectionViewDelegateFl
             if let error = error {
                 snapshot.appendItems([.error(ErrorDetails(error))], toSection: self.mainSection)
             } else if issues.isEmpty {
+                // Technically we could query a repo with no issues and result in infinite loading indicator,
+                // but what are the chances of that...
                 print("Displaying loading indicator")
                 snapshot.appendItems([.loading], toSection: self.mainSection)
             } else {


### PR DESCRIPTION
 ### Summary

Load blog posts in the issues list while displaying the loading indicator and errors inline. 

### Implementation details

* Loading
  * Remove loading from ViewController
  * Create a collection view cell to display a loading indicator
* Logic
  * Refactor the data source to display `Row` instead of `Issue`
  * Add `@Published issues` to the view model 
  * Add `@Published error` to the `IssueViewModel`
  * Subscribe to those instead of accessing the viewmodel directly; display either loading, issues or an error. 
* Error handling
  * Add user facing `title` and `description` to `NetworkingError`
  * Display the error information in a new cell

### Acceptance Criteria

Display loading indicator in the top center while blog posts download
Display error if the download fails

### Images

![Simulator Screen Shot - iPhone 14 - 2022-12-06 at 12 49 51](https://user-images.githubusercontent.com/5884570/205985044-41ecfe5f-26a3-4fc5-84f3-f2a7a282efa1.png)

![Simulator Screen Shot - iPhone 14 - 2022-12-06 at 11 39 44](https://user-images.githubusercontent.com/5884570/205985180-5a0227cc-bb1c-4e3e-9e2f-aaead3d2462e.png)

